### PR TITLE
Fix build problem caused by "" in font-family css definition

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/shapes/bpmn-shapes.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/shapes/bpmn-shapes.css
@@ -852,7 +852,7 @@
  */
 #text {
     opacity: 1;
-    font-family: "Open Sans";
+    font-family: Open Sans;
     font-size: 12px;
     fill: #000000;
     stroke: #393f44;


### PR DESCRIPTION
The problem is that our parser supports only definition without "" this fixes it to not use "" so parser can be built correctly.